### PR TITLE
added variable to specify GPU(s) to apply fan curve to

### DIFF
--- a/nvidia_fan_control.py
+++ b/nvidia_fan_control.py
@@ -6,6 +6,9 @@ import os
 temperature_points = [0, 40, 57, 70]
 fan_speed_points = [27, 40, 80, 100]
 
+# GPU(s) to apply fan curve to (use [] for all GPUs)
+gpus = []
+
 # Sleep interval to reduce CPU activity
 sleep_seconds = 5
 
@@ -29,10 +32,13 @@ for i in range(device_count):
     handle = nvmlDeviceGetHandleByIndex(i)
     fan_count = nvmlDeviceGetNumFans(handle)
     name = nvmlDeviceGetName(handle)
-    handles.append(handle)
-    fan_counts.append(fan_count)
-    print(f"GPU {i}: {name}")
-    print(f"Fan Count: {fan_count}")
+    if not gpus or i in gpus:
+        handles.append(handle)
+        fan_counts.append(fan_count)
+        print(f"GPU {i}: {name}")
+        print(f"Fan Count: {fan_count}")
+    else:
+        print(f"Skipping GPU {i}: {name}")
 
 # Initialize starting temperatures and fan speed
 step_down_temperature = 0

--- a/nvidia_fan_control.py
+++ b/nvidia_fan_control.py
@@ -6,7 +6,9 @@ import os
 temperature_points = [0, 40, 57, 70]
 fan_speed_points = [27, 40, 80, 100]
 
-# GPU(s) to apply fan curve to (use [] for all GPUs)
+# GPU(s) to apply fan curve to
+# 0 is the first GPU, 2 the second, etc.
+# Use [] for all GPUs
 gpus = []
 
 # Sleep interval to reduce CPU activity


### PR DESCRIPTION
I have 2 different Nvidia GPUs: a 3090 Founders Edition and an EVGA 3090. Only my EVGA has issues with annoying fan behavior. Applying the same curve to both cards makes the EVGA more quiet and the Founders Edition more noisy. So I added an option to the script to allow you to specify which GPUs should be controlled by this script.