### PR TITLE
added SIGTERM signal handler for main loop

### DIFF
--- a/nvidia_fan_control.py
+++ b/nvidia_fan_control.py
@@ -1,6 +1,7 @@
 import time
 from pynvml import *
 import os
+import signal
 
 # Fan curve parameters
 temperature_points = [0, 40, 57, 70]
@@ -122,8 +123,18 @@ def print_info(info):
 
 # Main loop
 last_lines = 0
+terminate = False
+
+# Handler to terminate main loop
+def signal_handler(sig, frame):
+    global terminate
+    terminate = True
+
+# Register signal handler to gracefully shutdown
+signal.signal(signal.SIGTERM, signal_handler)
+
 try:
-    while True:
+    while not terminate:
         for handle, fan_count in zip(handles, fan_counts):
             # get the temperature
             temperature = nvmlDeviceGetTemperature(handle, NVML_TEMPERATURE_GPU)


### PR DESCRIPTION
I've noticed that using the shell approach in a systemd service, as discussed in[ this issue](https://github.com/RoversX/nvidia_fan_control_linux/issues/1), results in Python subprocesses not shutting down when running systemctl restart or systemctl stop (e.g., during fan curve updates). To address this, I have implemented a signal handler to ensure a graceful shutdown (and restoration of defaults) when a SIGTERM signal is received.

To make this fix effective, the ExecStart in the service configuration also needs to be updated:
`ExecStart=/bin/bash -c 'cd /path/to/nvidia_fan_control_linux && source fan/bin/activate && python nvidia_fan_control.py'`