### PR TITLE
Replace pynvml with nvidia-ml-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Activate Environment
 ```bash
 source fan/bin/activate
 ```
-Install pynvml
+Install nvidia-ml-py
 ```bash
-pip3 install pynvml
+pip3 install nvidia-ml-py
 ```
 Get python file
 ```bash


### PR DESCRIPTION
pynvml was deprecated in Sep 2025, but it seems like nvidia-ml-py is a drop-in replacement (at least for this tool).